### PR TITLE
Github actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
           yarn run build
       - name: Copy package.json to target
         run: cp package.json target
+      - name: Copy cloudformation.yaml to target
+        run: cp cloudformation.yaml target
       - name: Go to target and install everything there in prod mode
         run: |
           cd target
@@ -48,7 +50,7 @@ jobs:
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          role-session-name: kindle-publication-check-build
+          role-session-name: formstack-submitter-ts-build
       - name: Send the .zip and riff-raff.yaml files from dist to S3
         uses: guardian/actions-riff-raff@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,18 +33,12 @@ jobs:
           yarn run build
       - name: Copy package.json to target
         run: cp package.json target
-      - name: Copy cloudformation.yaml to target
-        run: cp cloudformation.yaml target
-      - name: Go to target and install everything there in prod mode
+      - name: Prepare the bundle
         run: |
+          mkdir -p dist
           cd target
+          zip -r ../dist/formstack-submitter-ts.zip *
           yarn --production
-      - name: Head back up a dir
-        run: cd ..
-      - name: Make a dist dir and create a .zip file there
-        run: |
-          mkdir dist
-          zip -r dist/formstack-submitter-ts.zip target
       - name: Acquire RiffRaff AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ jobs:
           yarn run build
       - name: Copy package.json to target
         run: cp package.json target
-      - name: Copy cloudformation.yaml to target
-        run: cp cloudformation.yaml target
       - name: Go to target and install everything there in prod mode
         run: |
           cd target
@@ -61,3 +59,4 @@ jobs:
           contentDirectories: |
             formstack-submitter-ts:
               - dist/formstack-submitter-ts.zip
+              - cloudformation.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
         run: |
           mkdir -p dist
           cd target
-          zip -r ../dist/formstack-submitter-ts.zip *
           yarn --production
+          zip -r ../dist/formstack-submitter-ts.zip *
       - name: Acquire RiffRaff AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+# Initiate a github actions-initiated build
+name: Build and upload artifact on push to any branch
+on:
+  push: {}
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Prepare Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      # Seed the build number with last number from TeamCity.
+      - name: Update GITHUB_RUN_NUMBER
+        run: |
+          LAST_TEAMCITY_BUILD=85
+          echo GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD )) >> $GITHUB_ENV
+      # now following example at https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs#example-using-yarn
+      - name: Install dependencies with yarn
+        run: yarn
+      - name: Clean and build target
+        run: |
+          yarn run clean
+          yarn run build
+      - name: Copy package.json to target
+        run: cp package.json target
+      - name: Go to target and install everything there in prod mode
+        run: |
+          cd target
+          yarn --production
+      - name: Head back up a dir
+        run: cd ..
+      - name: Make a dist dir and create a .zip file there
+        run: |
+          mkdir dist
+          zip -r dist/formstack-submitter-ts.zip target
+      - name: Acquire RiffRaff AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          role-session-name: kindle-publication-check-build
+      - name: Send the .zip and riff-raff.yaml files from dist to S3
+        uses: guardian/actions-riff-raff@v2
+        with:
+          # use projectName to override use of riff-raff.yaml's stack value as S3 prefix
+          projectName: Content Platforms::formstack-submitter-ts
+          configPath: riff-raff.yaml
+          buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
+          contentDirectories: |
+            formstack-submitter-ts:
+              - dist/formstack-submitter-ts.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,4 +61,5 @@ jobs:
           contentDirectories: |
             formstack-submitter-ts:
               - dist/formstack-submitter-ts.zip
+            cloudformation:
               - cloudformation.yaml

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -16,5 +16,5 @@ deployments:
     parameters:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: formstack-submitter-ts
-      templatePath: cloudformation/cloudformation.yaml
+      templatePath: cloudformation.yaml
       cloudFormationStackByTags: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
       bucketSsmLookup: true
       fileName: formstack-submitter-ts.zip
       functionNames: [formstack-submitter-ts-]
-  formstack-submitter-ts-cloudformation:
+  cloudformation:
     type: cloud-formation
     app: formstack-submitter-ts
     parameters:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,7 +4,7 @@ regions: [eu-west-1]
 deployments:
   formstack-submitter-ts:
     type: aws-lambda
-    dependencies: [formstack-submitter-ts-cloudformation]
+    dependencies: [cloudformation]
     parameters:
       prefixStack: false
       bucketSsmLookup: true


### PR DESCRIPTION
## What does this change?

- Moves the build over to Github Actions

This was done because for some reason, builds were not moving from TeamCity into Riffraff.  Because TeamCity is being deprecated, I ported the build to the newly recommended platform instead.

## How to test

Check that it builds, then check that it deploys. Simples!

## How can we measure success?

Able to deploy new builds again
