### PR TITLE
Restrict concurrent executions of public facing lambda

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -38,6 +38,7 @@ Resources:
       Handler: lambda.handler
       MemorySize: 128
       Timeout: 300
+      ReservedConcurrentExecutions: 20
       Environment:
         Variables:
           Stage: !Ref Stage


### PR DESCRIPTION
## What does this change?

This lambda serves a public-facing API, so we'll restrict its concurrent executions to prevent it from hogging concurrency elsewhere in the estate.
