### PR TITLE
Rename references to OAuth token to API token, and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ If the integration with Formstack is broken, it’s likely due to an expired or 
 To resolve this, contact Central Production for Admin access to the Formstack account. The simplest solution is to generate a new access token by creating a new API Application.
 
 Then, update the Cloudformation stack entry.
+
+This repo uses the same credentials that https://github.com/guardian/targeting uses for authenticating with Formstack.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-# Formstack Submitter 
+# Formstack Submitter
 
-This lambda receives HTTP POST requests from Frontend and MAPI and sends them on to the Formstack database. 
+This lambda receives HTTP POST requests from Frontend and MAPI and sends them on to the Formstack database.
 
 The data comes from reader callout forms submitted on the user interface.
 
-# To test locally
+## To test locally
 
 Run the local file: `npm run runlocal`
-Ensure to put environment variables `formstack_url` and `oauth_token` on terminal before running above command.
+Ensure to put environment variables `FORMSTACK_TOKEN` and `API_TOKEN` on terminal before running above command.
 Please refer stage CODE in content-api stack.
 
+## Formstack integration issues
 
+If the integration with Formstack is broken, it’s likely due to an expired or deactivated access token. Access tokens are linked to users and can be deactivated when users lose access to their accounts.
+
+To resolve this, contact Central Production for Admin access to the Formstack account. The simplest solution is to generate a new access token by creating a new API Application.
+
+Then, update the Cloudformation stack entry.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The data comes from reader callout forms submitted on the user interface.
 ## To test locally
 
 Run the local file: `npm run runlocal`
-Ensure to put environment variables `FORMSTACK_TOKEN` and `API_TOKEN` on terminal before running above command.
+Ensure to put environment variables `FORMSTACK_URL` and `API_TOKEN` on terminal before running above command.
 Please refer stage CODE in content-api stack.
 
 ## Formstack integration issues

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,12 +1,12 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
-Description: Forwards POST requests from Frontend & MAPI to our Formstack account 
+Description: Forwards POST requests from Frontend & MAPI to our Formstack account
 
 Parameters:
   Stack:
     Description: Stack name
     Type: String
-    Default: content-api 
+    Default: content-api
   App:
     Description: Application name
     Type: String
@@ -21,7 +21,7 @@ Parameters:
     Description: Bucket to copy files to
     Type: String
     Default: content-api-dist
-  OAuthToken:
+  ApiToken:
     Description: Token used for Formstack authentication
     Type: String
   FormStackUrl:
@@ -33,7 +33,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${App}-${Stage}
-      Description: Sends requests to Formstack 
+      Description: Sends requests to Formstack
       Runtime: nodejs18.x
       Handler: lambda.handler
       MemorySize: 128
@@ -42,7 +42,7 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          OAUTH_TOKEN: !Ref OAuthToken
+          API_TOKEN: !Ref ApiToken
           FORMSTACK_URL: !Ref FormStackUrl
       CodeUri:
         Bucket: !Ref DeployBucket

--- a/src/submitter.ts
+++ b/src/submitter.ts
@@ -8,7 +8,7 @@ const reqHeaders = {
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
-    Authorization: `Bearer ${process.env.OAUTH_TOKEN}`,
+    Authorization: `Bearer ${process.env.API_TOKEN}`,
   },
 };
 


### PR DESCRIPTION
## What does this change?

Renames references to OAuth token to API token, and updates the repo documentation to give a path to resolution.

## How to test

Deploy cloudformation change, which includes the new param, and then code changes, to PROD. Formstack submissions should succeed.

- [x] Tested on PROD
