### PR TITLE
First attempt to fix the AWS callback issue

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,14 +1,25 @@
 import { sendToFormstack } from "./submitter";
 
-export const handler = async (event, context, callback): Promise<void> => {
+// export const handler = async (event, context, callback): Promise<void> => {
+//   console.log("Formstack Submitter ran");
+
+//   try {
+//     const result = await sendToFormstack(event);
+//     console.log("Response from Formstack:", result);
+//     callback(null, result);
+//   } catch (err) {
+//     console.error(err);
+//     callback(err);
+//   }
+// };
+
+export const handler = async (event): Promise<void> => {
   console.log("Formstack Submitter ran");
 
   try {
     const result = await sendToFormstack(event);
     console.log("Response from Formstack:", result);
-    callback(null, result);
   } catch (err) {
     console.error(err);
-    callback(err);
   }
 };

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,25 +1,14 @@
 import { sendToFormstack } from "./submitter";
 
-// export const handler = async (event, context, callback): Promise<void> => {
-//   console.log("Formstack Submitter ran");
-
-//   try {
-//     const result = await sendToFormstack(event);
-//     console.log("Response from Formstack:", result);
-//     callback(null, result);
-//   } catch (err) {
-//     console.error(err);
-//     callback(err);
-//   }
-// };
-
 export const handler = async (event): Promise<void> => {
   console.log("Formstack Submitter ran");
 
   try {
     const result = await sendToFormstack(event);
     console.log("Response from Formstack:", result);
+    return result;
   } catch (err) {
     console.error(err);
+    throw err;
   }
 };

--- a/src/local.ts
+++ b/src/local.ts
@@ -13,6 +13,6 @@ const testfunc = (text: string): void => {
   console.log(text);
 };
 
-const run = async () => await handler(fakeEvent, "x", testfunc);
+const run = async () => await handler(fakeEvent);
 
 run();


### PR DESCRIPTION
## What does this change?
The update PR - https://github.com/guardian/formstack-submitter-ts/pull/44 - failed in PROD due to the following AWS error:

Runtime.CallbackHandlerDeprecated: ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html.

### Chat with CoPilot
> This PR failed in production. Logs show the following error message: "Runtime.CallbackHandlerDeprecated: ERROR: AWS Lambda has removed support for callback-based function handlers starting with Node.js 24. You need to modify this function to use a supported handler signature to use Node.js 24 or later. For more information see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html." Please review the files in this repo and advise on the best way to fix

The error mentioned indicates that callback-based function handlers are no longer supported in AWS Lambda starting with Node.js 24, and the issue lies in the following handler definition in src/lambda.ts:

```
import { sendToFormstack } from "./submitter";

export const handler = async (event, context, callback): Promise<void> => {
  console.log("Formstack Submitter ran");

  try {
    const result = await sendToFormstack(event);
    console.log("Response from Formstack:", result);
    callback(null, result);
  } catch (err) {
    console.error(err);
    callback(err);
  }
};
```

**Root Cause**

The problem arises because this function uses a callback parameter that relies on AWS Lambda’s now-deprecated callback-based handler signature.

**Recommended Fix**
To comply with the requirements for Node.js 24, the handler should be updated to remove the callback entirely and rely on the async behavior provided by the new supported handler signature. This would involve:

1. Removing the callback parameter from the handler.
2. Returning the response or propagating the error using return or throw statements, respectively.

The fixed handler might look as follows:

```
import { sendToFormstack } from "./submitter";

export const handler = async (event, context): Promise<any> => {
  console.log("Formstack Submitter ran");

  try {
    const result = await sendToFormstack(event);
    console.log("Response from Formstack:", result);
    return result;
  } catch (err) {
    console.error(err);
    throw err;
  }
};
```

**Next Steps**

1. Apply the above fix to the Lambda handler in the src/lambda.ts file.
2. Redeploy the Lambda function.
3. Test in the staging/CODE environment first to ensure the issue is resolved before redeploying in production.
